### PR TITLE
first-viewとthumbnail-card-areaの重なりを修正

### DIFF
--- a/app/components/first-view.tsx
+++ b/app/components/first-view.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 const FirstView = () => {
   return (
     <Box
+      position={"relative"}
       height={{ xs: "65vh", md: "80vh" }}
       sx={{
         backgroundImage: `url("/img/seikei-library.jpeg")`,
@@ -13,13 +14,14 @@ const FirstView = () => {
       }}
     >
       <Box
-        width={"100%"}
         height={"100%"}
         sx={{ WebkitBackdropFilter: "blue(8px)", backdropFilter: "blur(8px)" }}
       >
         <Box
           height={"100%"}
           display={"flex"}
+          alignItems={"center"}
+          justifyContent={"center"}
           flexDirection={{ xs: "column-reverse", md: "row" }}
           mx={{ md: 7 }} //2つのBoxを横並びにする
         >
@@ -29,7 +31,7 @@ const FirstView = () => {
             alignItems={"center"}
             justifyContent={"center"}
             flexDirection={"column"} //TypographyとButtonを縦並びにする
-            m={{ xs: 6, md: 0 }}
+            mt={{ xs: 6, md: 0 }}
           >
             <Typography fontSize={{ xs: 22, md: 30 }} my={{ xs: 2, md: 3 }}>
               PeachTechへようこそ！

--- a/app/components/thumbnail-card-area.tsx
+++ b/app/components/thumbnail-card-area.tsx
@@ -5,28 +5,28 @@ import { Box } from "@mui/material";
 
 const ThumbnailCardArea = () => {
   return (
-      <Box px={{ xs: 2, md: 15 }} bgcolor={"#fff7f7"}>
-        <Grid container spacing={4} padding={3}>
-          {cardData.map((data) => (
-            <Grid
-              item
-              xs={12}
-              sm={4}
-              md={4}
-              key={data.number}
-              display={"flex"}
-              justifyContent={"center"}
-              alignContent={"center"}
-            >
-              <ThumbnailCard
-                title={data.title}
-                imageSrc={data.imageSrc}
-                number={data.number}
-              />
-            </Grid>
-          ))}
-        </Grid>
-      </Box>
+    <Box px={{ xs: 2, md: 15 }} bgcolor={"#fff7f7"} mt={4}>
+      <Grid container spacing={4} padding={3}>
+        {cardData.map((data) => (
+          <Grid
+            item
+            xs={12}
+            sm={4}
+            md={4}
+            key={data.number}
+            display={"flex"}
+            justifyContent={"center"}
+            alignContent={"center"}
+          >
+            <ThumbnailCard
+              title={data.title}
+              imageSrc={data.imageSrc}
+              number={data.number}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
   );
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,13 @@
 import FirstView from "./components/first-view";
 import ThumbnailCardArea from "./components/thumbnail-card-area";
 
-const Home = () =>{
+const Home = () => {
   return (
     <>
       <FirstView />
       <ThumbnailCardArea />
     </>
   );
-}
+};
 
 export default Home;


### PR DESCRIPTION
# 修正前
以下の写真のようにfirst-viewとthumbnail-card-areaが重なり、境目のぼかしが変にかかっていたのでその修正をしました。
<img width="1470" alt="image" src="https://github.com/Peach-Tech0927/PeachTech-tutorial/assets/157810432/ac3278cd-3650-4d59-86b1-137e48309a2c">

# 修正後
## PC
<img width="1470" alt="image" src="https://github.com/Peach-Tech0927/PeachTech-tutorial/assets/157810432/730346a7-6653-431c-8f6d-e7c12ad56bbf">

## SP
<img width="1470" alt="image" src="https://github.com/Peach-Tech0927/PeachTech-tutorial/assets/157810432/922994e4-fbc0-4007-8ec1-a3c390fb8ebe">
